### PR TITLE
LPS-73518 Javadoc

### DIFF
--- a/modules/apps/web-experience/portlet-display-template/portlet-display-template/src/main/java/com/liferay/portlet/display/template/internal/PortletDisplayTemplateImpl.java
+++ b/modules/apps/web-experience/portlet-display-template/portlet-display-template/src/main/java/com/liferay/portlet/display/template/internal/PortletDisplayTemplateImpl.java
@@ -375,6 +375,21 @@ public class PortletDisplayTemplateImpl implements PortletDisplayTemplate {
 			request, response, ddmTemplate, entries, contextObjects);
 	}
 
+	/**
+	 * Returns the contents of the current ddmTemplate
+	 *
+	 * @param request Normally the HttpServletRequest corresponding to a portlet render. If it is not,
+	 *                (such as an HttpServletRequest corresponding to a portlet action or resource request,
+	 *                or for a regular servlet), the "renderRequest" variable will not be accessible to the template.
+	 * @param response Normally the HttpServletResponse corresponding to a portlet render. If it is not,
+	 *                (such as an HttpServletResponse corresponding to a portlet action or resource response,
+	 *                or for a regular servlet), the "renderResponse" variable will not be accessible to the template.
+	 * @param ddmTemplate The template to be rendered.
+	 * @param entries The entries in the template.
+	 * @param contextObjects Stores the parameters used to get the template content.
+	 * @return
+	 * @throws Exception
+	 */
 	@Override
 	public String renderDDMTemplate(
 			HttpServletRequest request, HttpServletResponse response,


### PR DESCRIPTION
The current behavior is that the renderDDMTemplate method inside of PortletDisplayTemplateImpl takes an HttpServletRequest and an HttpServletResponse as parameters but then casts them both as RenderRequest and RenderResponse respectively. My fix removes this unsafe typecast to these variables and in doing so allows the method to be called from phases different from the Render Phase. However, by calling it from outside of the Render Phase, the RenderRequest and RenderResponse variables are inaccessible and so the proposed documentation here makes that clear as well as that this method is intended to be called during the Render Phase.

Resent from https://github.com/codyhoag/liferay-portal/pull/84 with suggested changes.